### PR TITLE
Fixed form-missing error in visual studio

### DIFF
--- a/TeensyFlasher/TeensyFlasher.csproj
+++ b/TeensyFlasher/TeensyFlasher.csproj
@@ -72,7 +72,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="frmMain.cs" />
+    <Compile Include="frmMain.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="frmMain.Designer.cs">
       <DependentUpon>frmMain.cs</DependentUpon>
     </Compile>

--- a/TeensyFlasher/frmMain.cs
+++ b/TeensyFlasher/frmMain.cs
@@ -21,18 +21,7 @@ using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace TeensyFlasher
 {
-    public class TeensyFirmwareItem
-    {
-        public string DisplayText { get; set; }
-        public string Location { get; set; }
 
-        // Constructor
-        public TeensyFirmwareItem(string displayText, string location)
-        {
-            DisplayText = displayText;
-            Location = location;
-        }
-    }
     public partial class frmMain : Form
     {
         private AutoResetEvent _waitForAckNak = new AutoResetEvent(false);
@@ -858,4 +847,16 @@ namespace TeensyFlasher
 
     }
 
+    public class TeensyFirmwareItem
+    {
+        public string DisplayText { get; set; }
+        public string Location { get; set; }
+
+        // Constructor
+        public TeensyFirmwareItem(string displayText, string location)
+        {
+            DisplayText = displayText;
+            Location = location;
+        }
+    }
 }


### PR DESCRIPTION
Moved TeensyFirmwareItem class to bottom, and also fixed the csproj section:

    <Compile Include="frmMain.cs" />
to
    <Compile Include="frmMain.cs">
      <SubType>Form</SubType>
    </Compile>