### PR TITLE
Fix nullable reference type warnings

### DIFF
--- a/AOGConfigOMatic/AgOpenGPS/AgOpenGpsControl.cs
+++ b/AOGConfigOMatic/AgOpenGPS/AgOpenGpsControl.cs
@@ -254,7 +254,7 @@ namespace AOGConfigOMatic.AgOpenGPS
             try
             {
                 // Search for agopengps.exe recursively in the download path
-                string agOpenGpsExe = null;
+                string? agOpenGpsExe = null;
                 
                 if (Directory.Exists(_downloadPath))
                 {
@@ -309,7 +309,7 @@ namespace AOGConfigOMatic.AgOpenGPS
         private void UpdateLocalInstallationInfo()
         {
             // Search for agopengps.exe recursively in the download path
-            string agOpenGpsExe = null;
+            string? agOpenGpsExe = null;
             
             if (Directory.Exists(_downloadPath))
             {
@@ -391,7 +391,7 @@ namespace AOGConfigOMatic.AgOpenGPS
                     if (chkStartWithWindows.Checked)
                     {
                         // Find AgOpenGPS executable to add to startup
-                        string agOpenGpsExe = null;
+                        string? agOpenGpsExe = null;
                         if (Directory.Exists(_downloadPath))
                         {
                             var exeFiles = Directory.GetFiles(_downloadPath, "agopengps.exe", SearchOption.AllDirectories);
@@ -433,7 +433,7 @@ namespace AOGConfigOMatic.AgOpenGPS
             try
             {
                 // Find AgOpenGPS executable
-                string agOpenGpsExe = null;
+                string? agOpenGpsExe = null;
                 if (Directory.Exists(_downloadPath))
                 {
                     var exeFiles = Directory.GetFiles(_downloadPath, "agopengps.exe", SearchOption.AllDirectories);
@@ -460,7 +460,7 @@ namespace AOGConfigOMatic.AgOpenGPS
                 
                 // Set shortcut properties
                 Type shortcutType = shortcut.GetType();
-                shortcutType.InvokeMember("TargetPath", System.Reflection.BindingFlags.SetProperty, null, shortcut, new object[] { agOpenGpsExe });
+                shortcutType.InvokeMember("TargetPath", System.Reflection.BindingFlags.SetProperty, null, shortcut, new object?[] { agOpenGpsExe });
                 shortcutType.InvokeMember("WorkingDirectory", System.Reflection.BindingFlags.SetProperty, null, shortcut, new object[] { Path.GetDirectoryName(agOpenGpsExe) });
                 shortcutType.InvokeMember("Description", System.Reflection.BindingFlags.SetProperty, null, shortcut, new object[] { "AgOpenGPS - Precision Agriculture Application" });
                 shortcutType.InvokeMember("Save", System.Reflection.BindingFlags.InvokeMethod, null, shortcut, null);
@@ -664,39 +664,39 @@ namespace AOGConfigOMatic.AgOpenGPS
     {
 
         [JsonProperty("html_url")]
-        public string HTMLUrl { get; set; }
+        public string HTMLUrl { get; set; } = null!;
 
         [JsonProperty("tag_name")]
-        public string TagName { get; set; }
+        public string TagName { get; set; } = null!;
 
         [JsonProperty("name")]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         [JsonProperty("published_at")]
         public DateTime PublishedAt { get; set; }
 
         [JsonProperty("body")]
-        public string Body { get; set; }
+        public string Body { get; set; } = null!;
 
         [JsonProperty("prerelease")]
         public bool IsPrerelease { get; set; }
 
         [JsonProperty("assets")]
-        public List<ReleaseAsset> Assets { get; set; }
+        public List<ReleaseAsset> Assets { get; set; } = new List<ReleaseAsset>();
     }
 
     public class ReleaseAsset
     {
         [JsonProperty("name")]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         [JsonProperty("browser_download_url")]
-        public string DownloadUrl { get; set; }
+        public string DownloadUrl { get; set; } = null!;
 
         [JsonProperty("size")]
         public long Size { get; set; }
 
         [JsonProperty("content_type")]
-        public string ContentType { get; set; }
+        public string ContentType { get; set; } = null!;
     }
 }

--- a/AOGConfigOMatic/AioDeviceHelper.cs
+++ b/AOGConfigOMatic/AioDeviceHelper.cs
@@ -39,7 +39,7 @@ namespace AOGConfigOMatic
         /// <summary>
         /// Gets a specific type of AiO port
         /// </summary>
-        public static UsbSerialPortInfo GetAioPort(AioPortType portType)
+        public static UsbSerialPortInfo? GetAioPort(AioPortType portType)
         {
             var aioPorts = GetAioConfiguratorPorts();
             foreach (var port in aioPorts)

--- a/AOGConfigOMatic/AioPortIdentifier.cs
+++ b/AOGConfigOMatic/AioPortIdentifier.cs
@@ -13,7 +13,7 @@ namespace AOGConfigOMatic
         
         public static async Task<AioPortType> IdentifyPortByBehaviorAsync(string portName, CancellationToken cancellationToken)
         {
-            SerialPort serialPort = null;
+            SerialPort? serialPort = null;
             try
             {
                 serialPort = new SerialPort(portName, 115200, Parity.None, 8, StopBits.One);

--- a/AOGConfigOMatic/UM982/UM982Control.cs
+++ b/AOGConfigOMatic/UM982/UM982Control.cs
@@ -13,7 +13,6 @@ namespace AOGConfigOMatic.UM982
         private SerialPort? _serialPort = null;
         private bool isReadingData = false;
         private bool isClosing = false;
-        private string configurationFilenameUM982;
         private bool isProgrammingUM982 = false;
         private string rcvDataUM982 = string.Empty;
 
@@ -277,19 +276,22 @@ namespace AOGConfigOMatic.UM982
             btnConfigUM982.Enabled = false;
             btnConnectUM982.Enabled = false;
             btnURefreshUM982.Enabled = false;
+
+            // get receiver configuration file
+            string configurationFilenameUM982;
+            if (btnUMDual.Checked)
+            {
+                configurationFilenameUM982 = ".\\ConfigUM982D.txt";
+            }
+            else
+            {
+                configurationFilenameUM982 = ".\\ConfigUM982S.txt";
+            }
+
             string[]? lines = null;
 
             try
             {
-                // get receiver configuration file
-                if (btnUMDual.Checked)
-                {
-                    configurationFilenameUM982 = ".\\ConfigUM982D.txt";
-                }
-                else
-                {
-                    configurationFilenameUM982 = ".\\ConfigUM982S.txt";
-                }
                 lines = File.ReadAllLines(configurationFilenameUM982);
             }
             catch (Exception ex)


### PR DESCRIPTION
The project is explicitly configured for C# 8.0 (`<LangVersion>8.0</LangVersion>`) and nullable reference types (`<Nullable>enable</Nullable>`).
Unfortunately, newer language versions (> 7.3) are not officially supported for .NET Framework which leads to some confusing IntelliSense warnings.

I would suggest to do one of the following:
- Revert to C# 7.3 and remove nullable reference types
- Convert to the newer SDK-style project format, which should fix the IntelliSense issue (even though it is still not officially supported)